### PR TITLE
Запрет отправки запроса при пустом URL

### DIFF
--- a/js/counter.js
+++ b/js/counter.js
@@ -135,6 +135,12 @@ jQuery( document ).ready(function() {
 function SendOnce(type, id) {
 	
 	var request = bg_counter.counterurl+bg_counter.project+"/"+type+"/"+id;
+
+	// если при конфигурации была допущена ошибка и у нас нет итогового url, мы не отправим запрос
+	if (!request) {
+		console.error(`Ошибка в url ${request}`);
+		return null;
+	}
 	
 	jQuery.ajax ({
 		url: request,
@@ -270,6 +276,11 @@ function fullBatchQuery(socket) {
 				console.log(" Path ("+i+"): "+json);
 			}
 	
+			if (!request) {
+				console.error(`Ошибка в url ${request}`);
+				return null;
+			}
+
 			// Пакетный запрос batch-query
 			jQuery.ajax ({
 				url: request,

--- a/js/rating.js
+++ b/js/rating.js
@@ -83,6 +83,11 @@ function getRate(type, id) {
 	
 	var request = bg_counter.scoreurl+bg_counter.project+"/"+type+"/"+id;
 
+	if (!request) {
+		console.error(`Ошибка в url ${request}`);
+		return null;
+	}
+
 	jQuery.ajax ({
 		url: request,
 		type: "GET",
@@ -145,6 +150,11 @@ POST /rate/project/test/author/1/book/3
 function sendRate(type, id, number) {
 	
 	var request = bg_counter.rateurl+bg_counter.project+"/"+type+"/"+id;
+
+	if (!request) {
+		console.error(`Ошибка в url ${request}`);
+		return null;
+	}
 
 	jQuery.ajax ({
 		url: request,


### PR DESCRIPTION
Запрет отправки запроса при пустом URL.

Возникала ошибка, при которой запрос со страницы отправлялся на неё же саму, вместо /batch-query. Появлялась она как раз потому, что в локальном файле конфигурации отсутствовал необходимй URL для batch. С моим коммитом об этой ошибке будет сразу сообщено в консоль, а запрос выполнен не будет.

Предложения приветствуются.